### PR TITLE
fix: api keys are passed as command-line arguments w... in...

### DIFF
--- a/content-read-settings.js
+++ b/content-read-settings.js
@@ -4,16 +4,21 @@
  *
  * Usage:
  *
- * node content-read-settings.js https://blah.ghost.io CONTENT_API_KEY
+ * GHOST_CONTENT_API_KEY=your_key node content-read-settings.js https://blah.ghost.io
  */
 
-if (process.argv.length < 4) {
+if (process.argv.length < 3) {
     console.error('Missing an argument');
     process.exit(1);
 }
 
 const url = process.argv[2];
-const key = process.argv[3];
+const key = process.env.GHOST_CONTENT_API_KEY;
+
+if (!key) {
+    console.error('Missing GHOST_CONTENT_API_KEY environment variable');
+    process.exit(1);
+}
 
 const GhostContentAPI = require('@tryghost/content-api');
 

--- a/content-read-settings.js
+++ b/content-read-settings.js
@@ -7,7 +7,7 @@
  * GHOST_CONTENT_API_KEY=your_key node content-read-settings.js https://blah.ghost.io
  */
 
-if (process.argv.length < 3) {
+if (process.argv.length !== 3) {
     console.error('Missing an argument');
     process.exit(1);
 }


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `content-read-settings.js`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `content-read-settings.js:10` |
| **Assessment** | Likely exploitable |

**Description**: API keys are passed as command-line arguments which can be exposed via process listing commands (ps aux) on the host system, allowing attackers to read administrative credentials in clear text.

## Evidence

**Exploitation scenario**: An attacker with access to the host system (local user or compromised application) can run 'ps aux | grep node' or examine /proc/[pid]/cmdline to view the command-line arguments containing the Ghost.

**Scanner confirmation**: multi_agent_ai rule `V-001` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This is a Node.js library - vulnerabilities affect downstream consumers who use this package.

## Changes
- `content-read-settings.js`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
